### PR TITLE
Add support for local paths as --url options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ find build -iname "*.mp4"
 
 ## Authors
 
-- [Leo Stein](https://duetosymmetry.com/) ([@duetosymmetry](https://github.com/duetosymmetry))
 - [Matthew Feickert](http://www.matthewfeickert.com/) ([@matthewfeickert](https://github.com/matthewfeickert))
+- [Leo C. Stein](https://duetosymmetry.com/) ([@duetosymmetry](https://github.com/duetosymmetry))

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ FLAGS:
     -h, --help              Print help information and quit
 
 OPTIONS:
-        --url <url>         URL of the project Git repo (HTTPS or SSH)
+        --url <url>         URL of the project Git repo (HTTPS, SSH, or local path)
         --start <start>     Git commit hash to start at.
                             If left blank it will default to the first commit
                             in the project repo

--- a/papervis.sh
+++ b/papervis.sh
@@ -59,7 +59,7 @@ function make_all() {
         fi
         git checkout "$rev"
         makepaperrev
-    done < <(git rev-list --reverse "${1}..master")
+    done < <(git rev-list --reverse "${1}..origin/master")
 }
 
 function make_all_nup() {

--- a/papervis.sh
+++ b/papervis.sh
@@ -159,6 +159,9 @@ function main() {
         exit 1
     fi
 
+    # Clone and cd
+    prep_repo "${GIT_REPO_URL}"
+
     if [[ -z "${START_COMMIT_HASH}" ]]; then
         START_COMMIT_HASH="$(git rev-list --max-parents=0 HEAD)"
         printf "\n# Starting papervis at the first commit in the project Git repo: %s\n\n" "${START_COMMIT_HASH}"
@@ -167,8 +170,6 @@ function main() {
     fi
     sleep 2
 
-    # Execute
-    prep_repo "${GIT_REPO_URL}"
     if [[ ! -z "${MAKE_TARGET}" ]]; then
         make_all "${START_COMMIT_HASH}" "${MAKE_TARGET}"
     else

--- a/papervis.sh
+++ b/papervis.sh
@@ -11,7 +11,7 @@ FLAGS:
     -h, --help              Print help information and quit
 
 OPTIONS:
-        --url <url>         URL of the project Git repo (HTTPS or SSH)
+        --url <url>         URL of the project Git repo (HTTPS, SSH, or local path)
         --start <start>     Git commit hash to start at.
                             If left blank it will default to the first commit
                             in the project repo
@@ -24,7 +24,7 @@ EOF
 }
 
 function prep_repo() {
-    # 1: URL of Git repo
+    # 1: URL or path of Git repo
     git clone --recursive "${1}" build
     cd build
 }
@@ -150,7 +150,7 @@ function main() {
 
     # Check input values
     if [[ -z "${GIT_REPO_URL}" ]]; then
-        printf "\n# Enter the Git repo URL (HTTPS or SHH) with the --url option\n\n"
+        printf "\n# Enter the Git repo URL (HTTPS, SSH, or local path) with the --url option\n\n"
         exit 1
     fi
 


### PR DESCRIPTION
# Description

As Git can clone a local path in addition to a remote URL add support for using local paths for the `--url` option. If a local path is used for the `--url` option then there is no guarantee that the default branch created will be named `master`. To guard against this use `origin/master` instead (which is reasonable as `origin` is a very standard name for the default remote).

Additionally fix a bug where Git repo values were being accessed erroneously _before_ the repo was cloned.