### PR TITLE
Remove `--depth` clone option from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Visualize the paper writing process through your Git commit history
 This is custom software so it should be installed under `/opt` at
 
 ```
-git clone depth -1 https://github.com/matthewfeickert/papervis.git /opt/papervis
+git clone https://github.com/matthewfeickert/papervis.git /opt/papervis
 ```
 
 However, functionality to use it as a system wide command line utility hasn't been added yet. So for the time being you should clone it to wherever you'd like to run from.


### PR DESCRIPTION
The `git clone` command line in the README file was malformed. Either it should say `--depth 1` (with dashes in front of depth); or, more simply since we don't have any submodules, we can omit the depth flag.